### PR TITLE
Stop using apt-key for apt key management

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@ Debian 9). For othe distributions simple replace the URLs.
 	<li>
 	<li>Import key and update repos:<br>
 	<tt>
-		apt-key add Release.key<br>
+		mv Release.key /etc/apt/trusted.gpg.d/ra3xdh.asc<br>
 		apt-get update<br>
 	</tt>
 	<li>Install Qucs-S<br>


### PR DESCRIPTION
The `apt-key` tool is being [deprecated](https://manpages.debian.org/unstable/apt/apt-key.8.en.html#DEPRECATION) and on Debian sid I now get a warning like:
```
W: http://download.opensuse.org/repositories/home:/ra3xdh/Debian_11/./InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

The instructions should be updated to the long supported, now recommended, soon required approach of putting the key in its own file in `/etc/apt/trusted.gpg.d/`.